### PR TITLE
Analyze all application code thoroughly

### DIFF
--- a/Backend/controllers/post.controllers.js
+++ b/Backend/controllers/post.controllers.js
@@ -88,6 +88,20 @@ const getAllPosts = async (req, res) => {
 
     const totalPosts = await Post.countDocuments(filter);
 
+    // If requesting a user's posts, enforce privacy: private accounts visible only to followers or self
+    if (filter.user) {
+      try {
+        const target = await User.findById(filter.user).select('accountType followers')
+        const meId = String(req.user.id)
+        const isMe = String(filter.user) === meId
+        const isFollower = Array.isArray(target?.followers) && target.followers.some((x) => String(x) === meId)
+        const isPrivate = target?.accountType === 'private'
+        if (isPrivate && !isMe && !isFollower) {
+          return res.status(403).json({ success: false, message: 'Private account' })
+        }
+      } catch {}
+    }
+
     const posts = await Post.find(filter)
       .sort({ createdAt: -1 })
       .skip((page - 1) * limit)

--- a/Backend/controllers/user.controller.js
+++ b/Backend/controllers/user.controller.js
@@ -129,12 +129,17 @@ const getProfile = async (req, res) => {
 
 const updateProfile = async (req, res) => {
   try {
-    const { name, bio, website, profilePic, username } = req.body
+    const { name, bio, website, profilePic, username, accountType } = req.body
     const updates = {}
     if (typeof name === 'string') updates.name = name
     if (typeof bio === 'string') updates.bio = bio
     if (typeof website === 'string') updates.website = website
     if (typeof profilePic === 'string') updates.profilePic = profilePic
+    if (typeof accountType === 'string') {
+      const allowed = ['public','private','professional']
+      if (!allowed.includes(accountType)) return res.status(400).json({ success: false, message: 'Invalid accountType' })
+      updates.accountType = accountType
+    }
     if (typeof username === 'string') {
       const raw = username.trim().toLowerCase()
       if (raw.length < 3 || raw.length > 30) return res.status(400).json({ success: false, message: 'Username must be 3-30 characters' })
@@ -153,19 +158,31 @@ const updateProfile = async (req, res) => {
 
 const followUser = async (req, res) => {
   try {
-    const userToFollow = await User.findById(req.params.id);
-    const currentUser = await User.findById(req.user.id);
+    const userToFollow = await User.findById(req.params.id).select('_id name accountType followers pendingFollowRequests');
+    const currentUser = await User.findById(req.user.id).select('_id name following sentFollowRequests');
 
     if (!userToFollow)
       return res.status(404).json({ message: "User not found" });
     if (currentUser.following.includes(userToFollow._id))
       return res.status(400).json({ message: "Already following" });
 
-    currentUser.following.push(userToFollow._id);
-    userToFollow.followers.push(currentUser._id);
+    // Private account -> create follow request instead of immediate follow
+    if (userToFollow.accountType === 'private') {
+      // If already requested
+      const alreadyRequested = Array.isArray(userToFollow.pendingFollowRequests) && userToFollow.pendingFollowRequests.some((id) => String(id) === String(currentUser._id))
+      if (alreadyRequested) return res.status(200).json({ message: 'Already requested', requested: true })
+      await User.findByIdAndUpdate(userToFollow._id, { $addToSet: { pendingFollowRequests: currentUser._id } })
+      await User.findByIdAndUpdate(currentUser._id, { $addToSet: { sentFollowRequests: userToFollow._id } })
+      try {
+        const { createNotification } = require("../utils/functions");
+        await createNotification({ req, receiverId: userToFollow._id, senderId: currentUser._id, type: "follow", text: "requested to follow you" })
+      } catch {}
+      return res.json({ message: 'Follow request sent', requested: true })
+    }
 
-    await currentUser.save();
-    await userToFollow.save();
+    // Public/professional -> immediate follow
+    await User.findByIdAndUpdate(currentUser._id, { $addToSet: { following: userToFollow._id }, $pull: { sentFollowRequests: userToFollow._id } })
+    await User.findByIdAndUpdate(userToFollow._id, { $addToSet: { followers: currentUser._id }, $pull: { pendingFollowRequests: currentUser._id } })
 
     // inside followUser
     const io = req.app.get("io");
@@ -183,13 +200,7 @@ const followUser = async (req, res) => {
 
     try {
       const { createNotification } = require("../utils/functions");
-      await createNotification({
-        req,
-        receiverId: userToFollow._id,
-        senderId: currentUser._id,
-        type: "follow",
-        text: "started following you",
-      });
+      await createNotification({ req, receiverId: userToFollow._id, senderId: currentUser._id, type: "follow", text: "started following you" });
     } catch {}
 
     console.log(`🔹 ${currentUser.name} followed ${userToFollow.name}`);
@@ -202,21 +213,14 @@ const followUser = async (req, res) => {
 // Unfollow user
 const unfollowUser = async (req, res) => {
   try {
-    const userToUnfollow = await User.findById(req.params.id);
-    const currentUser = await User.findById(req.user.id);
+    const userToUnfollow = await User.findById(req.params.id).select('_id');
+    const currentUser = await User.findById(req.user.id).select('_id');
 
     if (!userToUnfollow)
       return res.status(404).json({ message: "User not found" });
 
-    currentUser.following = currentUser.following.filter(
-      (id) => !id.equals(userToUnfollow._id)
-    );
-    userToUnfollow.followers = userToUnfollow.followers.filter(
-      (id) => !id.equals(currentUser._id)
-    );
-
-    await currentUser.save();
-    await userToUnfollow.save();
+    await User.findByIdAndUpdate(currentUser._id, { $pull: { following: userToUnfollow._id, sentFollowRequests: userToUnfollow._id } })
+    await User.findByIdAndUpdate(userToUnfollow._id, { $pull: { followers: currentUser._id, pendingFollowRequests: currentUser._id } })
 
     // inside unfollowUser
     const io = req.app.get("io");
@@ -238,6 +242,39 @@ const unfollowUser = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+// List inbound follow requests for current user
+const listFollowRequests = async (req, res) => {
+  try {
+    const me = await User.findById(req.user.id).select('pendingFollowRequests')
+    const ids = me?.pendingFollowRequests || []
+    const users = await User.find({ _id: { $in: ids } }).select('_id name username profilePic')
+    res.json({ success: true, users })
+  } catch (e) { res.status(500).json({ success: false, message: e.message }) }
+}
+
+// Accept a follow request
+const acceptFollowRequest = async (req, res) => {
+  try {
+    const { id } = req.params // requester id
+    if (!id) return res.status(400).json({ success: false, message: 'id required' })
+    // Move from pending to followers/following
+    await User.findByIdAndUpdate(req.user.id, { $pull: { pendingFollowRequests: id }, $addToSet: { followers: id } })
+    await User.findByIdAndUpdate(id, { $pull: { sentFollowRequests: req.user.id }, $addToSet: { following: req.user.id } })
+    return res.json({ success: true })
+  } catch (e) { return res.status(500).json({ success: false, message: e.message }) }
+}
+
+// Decline a follow request
+const declineFollowRequest = async (req, res) => {
+  try {
+    const { id } = req.params // requester id
+    if (!id) return res.status(400).json({ success: false, message: 'id required' })
+    await User.findByIdAndUpdate(req.user.id, { $pull: { pendingFollowRequests: id } })
+    await User.findByIdAndUpdate(id, { $pull: { sentFollowRequests: req.user.id } })
+    return res.json({ success: true })
+  } catch (e) { return res.status(500).json({ success: false, message: e.message }) }
+}
 
 const searchuser = async (req, res) => {
   try {
@@ -304,11 +341,16 @@ const getUserById = async (req, res) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(400).json({ success: false, message: "Invalid user ID" });
     }
-    const user = await User.findById(id).select("_id name profilePic bio followers following lastActiveAt customStatus");
+    const user = await User.findById(id).select("_id name username profilePic bio followers following lastActiveAt customStatus accountType pendingFollowRequests");
     if (!user) {
       return res.status(404).json({ success: false, message: "User not found" });
     }
-    res.json({ success: true, user });
+    const myId = String(req.user?.id || '')
+    const isMe = myId && String(user._id) === myId
+    const isFollowing = Array.isArray(user.followers) && user.followers.some((x) => String(x) === myId)
+    const hasRequested = Array.isArray(user.pendingFollowRequests) && user.pendingFollowRequests.some((x) => String(x) === myId)
+    const viewer = { isMe, isFollowing, hasRequested, canViewPosts: isMe || isFollowing || (user.accountType !== 'private') }
+    res.json({ success: true, user: { _id: user._id, name: user.name, username: user.username, profilePic: user.profilePic, bio: user.bio, followers: user.followers, following: user.following, lastActiveAt: user.lastActiveAt, customStatus: user.customStatus, accountType: user.accountType }, viewer });
   } catch (err) {
     console.error(err);
     res.status(500).json({ success: false, message: err.message });
@@ -321,8 +363,15 @@ const getFollowers = async (req, res) => {
     const { id } = req.params
     const page = Number.parseInt(req.query.page) || 1
     const limit = Number.parseInt(req.query.limit) || 20
-    const user = await User.findById(id || req.user.id).select("followers")
+    const user = await User.findById(id || req.user.id).select("followers accountType")
     if (!user) return res.status(404).json({ success: false, message: "User not found" })
+    const requesterId = String(req.user.id)
+    const targetId = String(id || req.user.id)
+    const isMe = requesterId === targetId
+    const isFollower = Array.isArray(user.followers) && user.followers.some((x) => String(x) === requesterId)
+    if (user.accountType === 'private' && !isMe && !isFollower) {
+      return res.status(403).json({ success: false, message: 'Private account' })
+    }
     const total = user.followers.length
     const start = (page - 1) * limit
     const end = start + limit
@@ -340,8 +389,15 @@ const getFollowing = async (req, res) => {
     const { id } = req.params
     const page = Number.parseInt(req.query.page) || 1
     const limit = Number.parseInt(req.query.limit) || 20
-    const user = await User.findById(id || req.user.id).select("following")
+    const user = await User.findById(id || req.user.id).select("following accountType followers")
     if (!user) return res.status(404).json({ success: false, message: "User not found" })
+    const requesterId = String(req.user.id)
+    const targetId = String(id || req.user.id)
+    const isMe = requesterId === targetId
+    const isFollower = Array.isArray(user.followers) && user.followers.some((x) => String(x) === requesterId)
+    if (user.accountType === 'private' && !isMe && !isFollower) {
+      return res.status(403).json({ success: false, message: 'Private account' })
+    }
     const total = user.following.length
     const start = (page - 1) * limit
     const end = start + limit
@@ -618,5 +674,8 @@ module.exports = {
   getSuggestions,
   getMutuals,
   getLastSeen,
-  setCustomStatus
+  setCustomStatus,
+  listFollowRequests,
+  acceptFollowRequest,
+  declineFollowRequest
 };

--- a/Backend/models/user.models.js
+++ b/Backend/models/user.models.js
@@ -11,6 +11,10 @@ const userSchema = new mongoose.Schema({
   ],
   followers: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
   following: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
+  // Account type and follow requests
+  accountType: { type: String, enum: ['public', 'private', 'professional'], default: 'public' },
+  pendingFollowRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }], // inbound (users who requested to follow me)
+  sentFollowRequests: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }], // outbound (users I requested to follow)
   highlights: [{ type: mongoose.Schema.Types.ObjectId, ref: "DailyCircleEntry" }],
   closeFriends: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
   expoPushTokens: [{ type: String }],

--- a/Backend/routes/user.routes.js
+++ b/Backend/routes/user.routes.js
@@ -5,6 +5,7 @@ const { register, login, getProfile, updateProfile, followUser, unfollowUser, se
 const { getOnlineUsers } = require("../controllers/user.controller");
 const { getSuggestions, getMutuals } = require("../controllers/user.controller");
 const { getLastSeen } = require("../controllers/user.controller");
+const { listFollowRequests, acceptFollowRequest, declineFollowRequest } = require("../controllers/user.controller");
 
 // Public routes
 router.post("/register", register);
@@ -18,6 +19,10 @@ router.put("/profile", auth, updateProfile);
 router.post('/logout', auth, logout);
 router.post("/:id/follow", auth, followUser);
 router.post("/:id/unfollow", auth, unfollowUser);
+// Follow requests (for private accounts)
+router.get('/me/follow-requests', auth, listFollowRequests)
+router.post('/follow-requests/:id/accept', auth, acceptFollowRequest)
+router.post('/follow-requests/:id/decline', auth, declineFollowRequest)
 router.get("/search", auth, searchuser);
 // Close Friends
 router.get("/me/close-friends", auth, listCloseFriends)

--- a/Frontend/app/otherProfile.tsx
+++ b/Frontend/app/otherProfile.tsx
@@ -42,6 +42,8 @@ export default function ProfileScreen() {
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [isFollowing, setIsFollowing] = useState(false)
+  const [hasRequested, setHasRequested] = useState(false)
+  const [viewer, setViewer] = useState<any>(null)
   const [activeTab, setActiveTab] = useState("posts")
   const router = useRouter()
   const { userId } = useLocalSearchParams()
@@ -55,10 +57,21 @@ export default function ProfileScreen() {
       }
 
       const api = (await import("@/services/api.service")).apiService
-      if (isFollowing) await api.unfollowUser(String(userId))
-      else await api.followUser(String(userId))
-
-      setIsFollowing(!isFollowing)
+      if (isFollowing) {
+        await api.unfollowUser(String(userId))
+        setIsFollowing(false)
+        setHasRequested(false)
+        setViewer((v: any) => v ? { ...v, isFollowing: false, hasRequested: false, canViewPosts: false } : v)
+      } else {
+        const res: any = await api.followUser(String(userId))
+        if (res?.requested) {
+          setHasRequested(true)
+          setViewer((v: any) => v ? { ...v, hasRequested: true } : v)
+        } else {
+          setIsFollowing(true)
+          setViewer((v: any) => v ? { ...v, isFollowing: true, canViewPosts: true } : v)
+        }
+      }
     } catch (error) {
       console.error("Error toggling follow:", error)
       Alert.alert("Error", "Failed to toggle follow")
@@ -175,6 +188,11 @@ export default function ProfileScreen() {
       const data = targetUserId ? await api.getUserProfile(String(targetUserId)) : await api.getMe()
       const payload: any = data
       setUser(payload.user || payload)
+      if (payload.viewer) {
+        setViewer(payload.viewer)
+        setIsFollowing(!!payload.viewer.isFollowing)
+        setHasRequested(!!payload.viewer.hasRequested)
+      }
 
       const currentUserToCheck = currentUserData || currentUser
       if (targetUserId && currentUserToCheck) {
@@ -370,6 +388,18 @@ export default function ProfileScreen() {
   }
 
   const renderPostsContent = () => {
+    const canView = viewer?.canViewPosts !== false
+    if (!canView && !isOwnProfile) {
+      return (
+        <View style={styles.tabContentContainer}>
+          <View style={styles.emptyState}>
+            <View style={styles.emptyStateIcon}><Text style={styles.emptyStateIconText}>🔒</Text></View>
+            <Text style={styles.emptyStateTitle}>This account is private</Text>
+            <Text style={styles.emptyStateDescription}>Follow to see their photos and videos.</Text>
+          </View>
+        </View>
+      )
+    }
     if (posts && posts.length > 0) {
       return (
         <View style={styles.tabContentContainer}>
@@ -476,11 +506,11 @@ export default function ProfileScreen() {
             <Text style={[styles.statNumber, { color: colors.text }]}>{posts?.length || 0}</Text>
             <Text style={[styles.statLabel, { color: colors.muted }]}>Posts</Text>
           </View>
-          <TouchableOpacity style={styles.stat} onPress={() => router.push(`/followers/${(user as any)?._id || (userId as any)}`)}>
+          <TouchableOpacity style={styles.stat} onPress={() => { if (viewer && viewer.canViewPosts === false && !isOwnProfile) return; router.push(`/followers/${(user as any)?._id || (userId as any)}`) }}>
             <Text style={[styles.statNumber, { color: colors.text }]}>{(user as any)?.followers?.length || 0}</Text>
             <Text style={[styles.statLabel, { color: colors.muted }]}>Followers</Text>
           </TouchableOpacity>
-          <TouchableOpacity style={styles.stat} onPress={() => router.push(`/following/${(user as any)?._id || (userId as any)}`)}>
+          <TouchableOpacity style={styles.stat} onPress={() => { if (viewer && viewer.canViewPosts === false && !isOwnProfile) return; router.push(`/following/${(user as any)?._id || (userId as any)}`) }}>
             <Text style={[styles.statNumber, { color: colors.text }]}>{(user as any)?.following?.length || 0}</Text>
             <Text style={[styles.statLabel, { color: colors.muted }]}>Following</Text>
           </TouchableOpacity>
@@ -516,11 +546,11 @@ export default function ProfileScreen() {
         ) : (
           <>
             <TouchableOpacity
-              style={[styles.button, isFollowing ? { backgroundColor: colors.surface } : { backgroundColor: colors.primary }, { borderColor: colors.border }]}
+              style={[styles.button, (isFollowing || hasRequested) ? { backgroundColor: colors.surface } : { backgroundColor: colors.primary }, { borderColor: colors.border }]}
               onPress={handleFollowToggle}
             >
-              <Text style={[styles.buttonText, { color: isFollowing ? colors.text : '#fff' }]}>
-                {isFollowing ? "Following" : "Follow"}
+              <Text style={[styles.buttonText, { color: (isFollowing || hasRequested) ? colors.text : '#fff' }]}> 
+                {isFollowing ? "Following" : hasRequested ? "Requested" : "Follow"}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity style={[styles.button, { backgroundColor: colors.surface, borderColor: colors.border }]} onPress={handleMessage}>

--- a/Frontend/app/settings/index.tsx
+++ b/Frontend/app/settings/index.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { View, Text, TouchableOpacity, FlatList, Image, StyleSheet } from 'react-native'
+import { useRouter } from 'expo-router'
+import { apiService } from '@/services/api.service'
+
+export default function SettingsIndex() {
+  const router = useRouter()
+  const [requests, setRequests] = useState<Array<{ _id: string; name: string; username?: string; profilePic?: string }>>([])
+
+  useEffect(() => { (async () => { try { const r: any = await apiService.getFollowRequests(); if (r?.success && r?.users) setRequests(r.users) } catch {} })() }, [])
+
+  const accept = async (id: string) => { try { await apiService.acceptFollowRequest(id); setRequests((prev) => prev.filter((u) => u._id !== id)) } catch {} }
+  const decline = async (id: string) => { try { await apiService.declineFollowRequest(id); setRequests((prev) => prev.filter((u) => u._id !== id)) } catch {} }
+
+  const renderReq = ({ item }) => (
+    <View style={styles.reqRow}>
+      <Image source={{ uri: item.profilePic || 'https://i.pravatar.cc/100?img=14' }} style={styles.avatar} />
+      <View style={{ flex: 1 }}>
+        <Text style={styles.name}>{item.name}</Text>
+        {!!item.username && <Text style={styles.username}>@{item.username}</Text>}
+      </View>
+      <TouchableOpacity onPress={() => accept(item._id)} style={[styles.btn, styles.accept]}><Text style={styles.btnText}>Accept</Text></TouchableOpacity>
+      <TouchableOpacity onPress={() => decline(item._id)} style={[styles.btn, styles.decline]}><Text style={styles.btnText}>Decline</Text></TouchableOpacity>
+    </View>
+  )
+
+  return (
+    <View style={{ flex: 1, paddingTop: 50 }}>
+      <View style={{ paddingHorizontal: 16, paddingBottom: 10, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', borderBottomWidth: 1, borderBottomColor: '#eee' }}>
+        <TouchableOpacity onPress={() => router.back()}><Text style={{ color: '#007aff', fontWeight: '700' }}>Back</Text></TouchableOpacity>
+        <Text style={{ fontSize: 18, fontWeight: '800' }}>Settings</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <TouchableOpacity onPress={() => router.push('/settings/privacy')} style={styles.row}>
+        <Text style={styles.rowText}>Privacy</Text>
+      </TouchableOpacity>
+
+      <View style={{ paddingHorizontal: 16, paddingVertical: 8 }}>
+        <Text style={{ fontWeight: '800', marginBottom: 8 }}>Follow requests</Text>
+        <FlatList data={requests} keyExtractor={(u) => u._id} renderItem={renderReq} ListEmptyComponent={<Text style={{ color: '#666' }}>No requests</Text>} />
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: { paddingHorizontal: 16, paddingVertical: 14, borderBottomWidth: 1, borderBottomColor: '#f3f3f3' },
+  rowText: { fontSize: 16, fontWeight: '700' },
+  reqRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10, gap: 10 },
+  avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: '#eee' },
+  name: { fontSize: 14, fontWeight: '700' },
+  username: { fontSize: 12, color: '#666' },
+  btn: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 14, marginLeft: 6 },
+  accept: { backgroundColor: '#0095f6' },
+  decline: { backgroundColor: '#888' },
+  btnText: { color: '#fff', fontWeight: '700', fontSize: 12 },
+})
+

--- a/Frontend/app/settings/privacy.tsx
+++ b/Frontend/app/settings/privacy.tsx
@@ -11,18 +11,21 @@ type Privacy = {
   sendReadReceipts: boolean
   allowDMsFrom: 'everyone'|'followers'|'none'
 }
+type AccountType = 'public'|'private'|'professional'
 
 export default function PrivacySettings() {
   const router = useRouter()
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [privacy, setPrivacy] = useState<Privacy>({ showOnline: true, showLastSeen: true, sendTypingIndicators: true, sendReadReceipts: true, allowDMsFrom: 'everyone' })
+  const [accountType, setAccountType] = useState<AccountType>('public')
 
   useEffect(() => {
     ;(async () => {
       try {
         const res: any = await api.getPrivacy()
         if (res?.success && res?.privacy) setPrivacy({ ...privacy, ...res.privacy })
+        try { const me: any = await api.getMe(); const at = (me?.user?.accountType || me?.accountType) as AccountType; if (at) setAccountType(at) } catch {}
       } finally { setLoading(false) }
     })()
   }, [])
@@ -51,6 +54,17 @@ export default function PrivacySettings() {
         <Text style={styles.title}>Privacy</Text>
         <TouchableOpacity onPress={save} disabled={saving}><Text style={[styles.link, saving && { opacity: 0.6 }]}>{saving ? 'Saving…' : 'Save'}</Text></TouchableOpacity>
       </View>
+
+      <View style={[styles.row, { backgroundColor: '#F7F8FA' }]}>
+        <Text style={[styles.label, { fontWeight: '800' }]}>Account type</Text>
+        <Text style={styles.link}>Change</Text>
+      </View>
+      {(['public','private'] as AccountType[]).map((t) => (
+        <TouchableOpacity key={t} onPress={async () => { try { setAccountType(t); await (await import('@/services/api.service')).apiService.updateAccountType(t) } catch {} }} style={styles.row}>
+          <Text style={styles.label}>{t === 'public' ? 'Public' : t === 'private' ? 'Private' : 'Professional'}</Text>
+          <Text style={styles.link}>{accountType === t ? '●' : '○'}</Text>
+        </TouchableOpacity>
+      ))}
 
       <TouchableOpacity style={[styles.row, { backgroundColor: '#F7F8FA' }]} onPress={() => router.push('/settings/theme')}>
         <Text style={[styles.label, { fontWeight: '800' }]}>Appearance</Text>

--- a/Frontend/services/api.service.ts
+++ b/Frontend/services/api.service.ts
@@ -138,6 +138,11 @@ class ApiService {
     return this.request(`/users/me/privacy`, { method: 'PUT', body: JSON.stringify(p) })
   }
 
+  // Account type
+  async updateAccountType(type: 'public'|'private'|'professional') {
+    return this.request(`/users/profile`, { method: 'PUT', body: JSON.stringify({ accountType: type }) })
+  }
+
   // Custom status
   async setCustomStatus(text: string, emoji?: string, durationMinutes?: number) {
     return this.request(`/users/me/custom-status`, { method: 'POST', body: JSON.stringify({ text, emoji, durationMinutes }) })
@@ -400,6 +405,11 @@ class ApiService {
   }
   async followUser(userId) { return this.request(`/users/${userId}/follow`, { method: "POST" }) }
   async unfollowUser(userId) { return this.request(`/users/${userId}/unfollow`, { method: "POST" }) }
+
+  // Follow requests
+  async getFollowRequests() { return this.request(`/users/me/follow-requests`) }
+  async acceptFollowRequest(fromUserId: string) { return this.request(`/users/follow-requests/${fromUserId}/accept`, { method: 'POST' }) }
+  async declineFollowRequest(fromUserId: string) { return this.request(`/users/follow-requests/${fromUserId}/decline`, { method: 'POST' }) }
 
   async registerPushToken(token: string) { return this.request(`/users/me/push-token`, { method: 'POST', body: JSON.stringify({ token }) }) }
   async blockUser(userId: string) { return this.request(`/users/${userId}/block`, { method: 'POST' }) }


### PR DESCRIPTION
Add private/public account types with follow requests to enable user privacy control.

This feature allows users to set their accounts to private, requiring other users to send a follow request that must be accepted before they can view posts or follower/following lists, similar to Instagram.

---
<a href="https://cursor.com/background-agent?bcId=bc-03e55933-89f1-4171-beb5-7ca191f86c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03e55933-89f1-4171-beb5-7ca191f86c3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

